### PR TITLE
Add a tracking_id tag

### DIFF
--- a/GoogleAnalyticsTags.php
+++ b/GoogleAnalyticsTags.php
@@ -82,4 +82,19 @@ class GoogleAnalyticsTags extends Tags {
 
     return $data;
   }
+
+  /**
+   * The {{ google_analytics:tracking_id }} tag
+   *
+   * @return string
+   */
+  public function tracking_id() {
+    $tracking_id = str_replace(' ', '', $this->getConfig('tracking_id', ''), $value);
+
+    if (!empty($tracking_id)) {
+      return $tracking_id;
+    }
+
+    return '<!-- Google Analytics Tracking code is not setup yet! -->';
+  }
 }


### PR DESCRIPTION
This will output just the tracking id to use the plugin with other libraries like 'minimalanalytics' or advanced setups.